### PR TITLE
Fix database restart causes Todo app to crash

### DIFF
--- a/demo-node-todo/lib/routes_pg.js
+++ b/demo-node-todo/lib/routes_pg.js
@@ -1,101 +1,151 @@
-var pg = require('pg') // import the node pg module
-    _  = require('underscore');
+var pg = require('pg');
+var _ = require('underscore');
 
 // pg config, locally it's tcp://USERNAME@localhost:5432/tododb
 
-var pgConString = process.env.POSTGRES_URI;
+var pgURI = process.env.POSTGRES_URI;
 
-if (typeof pgConString !== "undefined") {
-  var pgClient = new pg.Client(pgConString); // initialize the node-postgres client
-
-  // connect to postgres
-  pgClient.connect(function(err) {
-    if (err) {
-      console.log('postgres connection error: ', err)
-    }
-  });
-
-
+if (typeof pgURI !== "undefined") {
   exports.createTables = function(req, res) {
-    pgClient.query('CREATE TABLE tasks (title text, completed boolean);', function(err, result) {
+    pg.connect(pgURI, function(err, client, done) {
       if (err) {
-        console.log('PGcreateTables error: ', err);
-        res.send(err);
-      } else {
+        console.error(err);
+        return;
+      }
+
+      client.query('CREATE TABLE tasks (title text, completed boolean);', function(err, result) {
+        if (err) {
+          console.error('PGcreateTables error: ', err);
+          res.send(err);
+          return;
+        }
+
         console.log('PGcreateTables result: ', result);
         res.send(result);
-      }
+      });
+
+      done();
     });
-  }
+  };
 
 
   exports.showTables = function(req, res) {
-    pgClient.query("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public';", function(err, result) {
+    pg.connect(pgURI, function(err, client, done) {
       if (err) {
-        console.log('PGshowTables error: ', err);
-        res.send(err);
-      } else{
+        console.error(err);
+        return;
+      }
+
+      client.query("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public';", function(err, result) {
+        if (err) {
+          console.error('PGshowTables error: ', err);
+          res.send(err);
+          return;
+        }
+
         console.log('PGshowTables result: ', result);
         res.send(result);
-      }
+      });
+
+      done();
     });
-  }
+  };
 
   exports.showTasks = function(req, res) {
-    pgClient.query('SELECT title, completed FROM tasks;', function(err, result) {
+    pg.connect(pgURI, function(err, client, done) {
       if (err) {
-        console.log('PGshowTasks error: ');
-        console.log(err);
-        res.send(err);
-      } else {
+        console.error(err);
+        return;
+      }
+
+      client.query('SELECT title, completed FROM tasks;', function(err, result) {
+        if (err) {
+          console.error('PGshowTasks error: ', err);
+          res.send(err);
+          return;
+        }
+
         console.log('PGshowTasks result: ', result);
         res.send(result);
-      }
+      });
+
+      done();
     });
-  }
+  };
 
   exports.deleteTables = function(req, res) {
-    pgClient.query("DROP TABLE tasks;", function(err, result) {
+    pg.connect(pgURI, function(err, client, done) {
       if (err) {
-        console.log('PGdeleteTables error: ', err);
-        res.send(err);
-      } else {
+        console.error(err);
+        return;
+      }
+
+      client.query("DROP TABLE tasks;", function(err, result) {
+        if (err) {
+          console.error('PGdeleteTables error: ', err);
+          res.send(err);
+          return;
+        }
+
         console.log('PGdeleteTables result: ', result);
         res.send(result);
-      }
+      });
+
+      done();
     });
-  }
+  };
 
   exports.addTask = function(req, res) {
-    // console.log('request body full: ', req.body);
-    var taskArray = req.body;
-    taskValues = _.map(taskArray, function(task) {
-      var valueTitle = "'" + task.title + "'",
-          valueCompleted = "'" + task.completed + "'";
-          return "(" + valueTitle + ", " + valueCompleted + ")";
-    });
-    var qs = 'INSERT into tasks (title, completed) VALUES ' + taskValues.join() + ";"
-    console.log(qs);
-    pgClient.query(qs, function(err, result) {
+    pg.connect(pgURI, function(err, client, done) {
       if (err) {
-        console.log('PGaddTask error: ', err);
-        res.send(err);
-      } else {
+        console.error(err);
+        return;
+      }
+
+      // console.log('request body full: ', req.body);
+      var taskArray = req.body;
+      var taskValues = _.map(taskArray, function(task) {
+        var valueTitle = "'" + task.title + "'";
+        var valueCompleted = "'" + task.completed + "'";
+        return "(" + valueTitle + ", " + valueCompleted + ")";
+      });
+
+      var qs = 'INSERT into tasks (title, completed) VALUES ' + taskValues.join() + ";";
+      console.log(qs);
+      client.query(qs, function(err, result) {
+        if (err) {
+          console.error('PGaddTask error: ', err);
+          res.send(err);
+          return;
+        }
+
         console.log('PGaddTask result: ', result);
         res.send(result);
-      }
+      });
+
+      done();
     });
-  }
+  };
 
   exports.deleteRows = function(req, res) {
-    pgClient.query("DELETE FROM tasks;", function(err, result) {
+    pg.connect(pgURI, function(err, client, done) {
       if (err) {
-        console.log('PGdeleteRows error: ', err);
-        res.send(err);
-      } else {
+        console.error(err);
+        return;
+      }
+
+      client.query("DELETE FROM tasks;", function(err, result) {
+        if (err) {
+          console.error('PGdeleteRows error: ', err);
+          res.send(err);
+          return;
+        }
+
         console.log('PGdeleteRows success: ', result);
         res.send(result);
-      }
+      });
+
+      done();
     });
-  }
+  };
 }


### PR DESCRIPTION
Currently, if a Postgres database is bound to demo-node-todo and the database job is restarted, demo-node-todo will crash. This uses client pooling instead of using the client object directly.

The node-postgres module recommends using this approach.
https://github.com/brianc/node-postgres/wiki/pg

@jcruz2us