### PR TITLE
Prevent EOL conversions on checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# These sample apps are written with the appropriate line endings for their
+# uses.  By default, on checkout line endings should be preserved rather than
+# converted by git.
+* -text


### PR DESCRIPTION
Many of these files are sensitive to EOL conversions since they are not
interpreted by the users OS at all, simply sent to the cluster for
processing where it would be assumed to be, usually, LF endings.

Rather than force eol=lf, simply preventing any conversion at all and
allowing users to commit the proper line endings.

@tcahill @zquestz