### PR TITLE
Don't echo user credentials

### DIFF
--- a/mysql-backup/bash_start.sh
+++ b/mysql-backup/bash_start.sh
@@ -3,7 +3,6 @@
 # Create cron job to backup the MySQL database
 
 set -e
-set -x
 
 DB_BACKUP_DIR=/backups/mysql-service
 

--- a/mysql-backup/mysql_backup.sh
+++ b/mysql-backup/mysql_backup.sh
@@ -5,7 +5,6 @@
 # Usage: /root/mysql_backup.sh $MYSQL_URI $DB_BACKUP_DIR
 
 set -e
-set -x
 
 DUMP_PRG=/usr/bin/mysqldump
 if ! [ -x $DUMP_PRG ]; then


### PR DESCRIPTION
Turned off echo (which was used for debugging) since it echos everything, including user credentials, which then get logged.

@lparis @alekstkach 