### PR TITLE
Create mysql-client package to use in mysql-backup sample app

### DIFF
--- a/mysql-backup/README.md
+++ b/mysql-backup/README.md
@@ -2,7 +2,7 @@
 
 This is a sample bash application that runs two scripts, as accepted by Apcera Platform's built-in bash stager:
 
-1. `bash_start.sh` installs the MySQL client software, creates a crontab file `/etc/cron.d/backup`, starts a monitoring loop, and starts cron.
+1. `bash_start.sh` creates a crontab file `/etc/cron.d/backup`, starts a monitoring loop, and starts cron.
 2. `mysql_backup.sh` is executed once an hour by cron. It backs up the MySQL server that's bound to the app and saves the backup onto the NFS service that's bound to the app.
 
 To create the app, perform the following:
@@ -31,4 +31,10 @@ Next, start the app as follows:
 apc app start mysql-backup-app
 ```
 
-Navigate to the URL provided from the app staging process to view the output page. It should display the number of seconds since the last successful backup. If a backup hasn't happened in over a day and a half it throws a 500 error and displays the number of seconds since the last successful backup. 
+Navigate to the URL provided from the app staging process to view the output page. You should see:
+
+* A 503 response code and the message "First backup has not completed" if no backups have yet completed.
+* A 200 response code and the message "Last backup completed [number of seconds] seconds ago" once hourly backups are running.
+* A 500 response code and the message "ERROR: No new backups in over [number of seconds] seconds" if a backup hasn't happened in over 12 hours.
+
+A monitoring application can check the URL and send an alert if the response code is an error.

--- a/mysql-backup/bash_start.sh
+++ b/mysql-backup/bash_start.sh
@@ -4,21 +4,21 @@
 
 set -e
 
+# Persistent mount point where the database is backed up
 DB_BACKUP_DIR=/backups/mysql-service
+
+# File that is touched when backup has completed by /root/mysql_backup.sh
+export BACKUP_COMPLETE=$DB_BACKUP_DIR/backup.complete
 
 # Make sure that the backup script is executable
 sudo chmod +x /app/mysql_backup.sh
 
-echo "==> INSTALLING mysql-client"
-
-# Install the MySQL client software, including mysqldump
-sudo apt-get update
-sudo apt-get install mysql-client -y
-
 echo "==> CONFIGURING crond"
 
 sudo -s -- <<EOF
-echo "# Backup the database every hour on the half hour" > /etc/cron.d/backup
+echo "PATH=$PATH" > /etc/cron.d/backup
+echo "BACKUP_COMPLETE=$BACKUP_COMPLETE" >> /etc/cron.d/backup
+echo "# Backup the database every hour on the half hour" >> /etc/cron.d/backup
 echo "30 * * * * root /app/mysql_backup.sh $MYSQL_URI $DB_BACKUP_DIR >> /tmp/cron.log 2>&1" >> /etc/cron.d/backup
 echo "# Delete backups after 30 days" >> /etc/cron.d/backup
 echo "15 1 * * * root /usr/bin/find $DB_BACKUP_DIR -name '*.gz' -mtime +30 -print0 | xargs --null --no-run-if-empty rm -f" >> /etc/cron.d/backup
@@ -26,20 +26,24 @@ chmod 0644 /etc/cron.d/backup
 touch /tmp/cron.log
 EOF
 
-# File that is touched when backup has completed by /root/mysql_backup.sh
-touch /tmp/backup.complete
-
 (
     while true; do
-        LAST_BACKUP=`stat -c '%Y' /tmp/backup.complete`
-        CURRENT_TIME=`date +'%s'`
-        BEHIND=$((CURRENT_TIME - LAST_BACKUP))
-        ONE_HALF_DAYS=129600
-
-        if [ $BEHIND -gt $ONE_HALF_DAYS ]; then
-            echo -ne "HTTP/1.0 500 OK\r\n\r\n${BEHIND}" | nc -l -p ${PORT:?}
+        if [ ! -d $DB_BACKUP_DIR ]; then
+            (>&2 echo "ERROR: Mount point '$DB_BACKUP_DIR' not found. Bind this job to a file service, use '$DB_BACKUP_DIR' as the mount point.")
+            exit 1
+        elif [ ! -e $BACKUP_COMPLETE ]; then
+            echo -ne "HTTP/1.0 503 OK\r\n\r\nFirst backup has not completed" | nc -l -p ${PORT:?}
         else
-            echo -ne "HTTP/1.0 200 OK\r\n\r\n${BEHIND}" | nc -l -p ${PORT:?}
+            LAST_BACKUP=`stat -c '%Y' $BACKUP_COMPLETE`
+            CURRENT_TIME=`date +'%s'`
+            BEHIND=$((CURRENT_TIME - LAST_BACKUP))
+            HALF_A_DAY=43200
+
+            if [ $BEHIND -gt $HALF_A_DAY ]; then
+                echo -ne "HTTP/1.0 500 OK\r\n\r\nERROR: No new backups in over ${BEHIND} seconds" | nc -l -p ${PORT:?}
+            else
+                echo -ne "HTTP/1.0 200 OK\r\n\r\nLast backup completed ${BEHIND} seconds ago" | nc -l -p ${PORT:?}
+            fi
         fi
     done
 ) &

--- a/mysql-backup/continuum.conf
+++ b/mysql-backup/continuum.conf
@@ -17,4 +17,8 @@ resources {
   network_bandwidth: "10Mbps"
 }
 
+package_dependencies: [
+  "runtime.mysql-client-5.6"
+]
+
 start: false

--- a/mysql-backup/mysql_backup.sh
+++ b/mysql-backup/mysql_backup.sh
@@ -4,11 +4,11 @@
 
 # Usage: /root/mysql_backup.sh $MYSQL_URI $DB_BACKUP_DIR
 
+DUMP_PRG=`which mysqldump`
 set -e
 
-DUMP_PRG=/usr/bin/mysqldump
-if ! [ -x $DUMP_PRG ]; then
-    echo "/usr/bin/mysqldump is not installed" >&2
+if ! [ -x "$DUMP_PRG" ]; then
+    echo "mysqldump is not installed" >&2
     exit 1
 fi
 
@@ -49,4 +49,4 @@ $DUMP_PRG --host=$URI_HOST --user=$URI_USER \
     --quick --routines --tz-utc --set-charset \
     $DBNAME | gzip > $DB_BACKUP_DIR/mysql-${DBNAME}-backup.$DATE.gz
 
-touch /tmp/backup.complete
+touch $BACKUP_COMPLETE


### PR DESCRIPTION
* Created a MySQL client package.
* Used this package in the `mysql-backup` sample app (in place of `apt-get`).
* Also updated the `bash_start.sh` script in `mysql-backup` sample app so that it
  returns a 503 (service unavailable) and the message "First backup has not completed"
  if the first backup has not yet been completed.
* Updated the docs as necessary.

Fixes #ENGT-8354

I had to update 6 repos and generate 6 PRs for this sample app.

@ketandixit @lilirui @variadico @yaso195