### PR TITLE
Moved mysql-client-5.6.31 from runtimes to packages

### DIFF
--- a/mysql-backup/continuum.conf
+++ b/mysql-backup/continuum.conf
@@ -18,7 +18,7 @@ resources {
 }
 
 package_dependencies: [
-  "runtime.mysql-client-5.6"
+  "package.mysql-client-5.6"
 ]
 
 start: false


### PR DESCRIPTION
Moved mysql-client-5.6.31 from runtimes to packages

Fixes #ENGT-8354

@zquestz @ketandixit @variadico 