### PR TITLE
Reuse newer node-4.4.6 package version

### DIFF
--- a/example-node-websocket/package.json
+++ b/example-node-websocket/package.json
@@ -7,5 +7,5 @@
   "dependencies": {
     "websocket": "*"
   },
-  "engines": { "node" : "0.8" }
+  "engines": { "node" : "4.4.6" }
 }


### PR DESCRIPTION
No need to use super old version of node for this app, that way we don't download and import needless extra packages.

@zquestz @lilirui @johnSchnake 