### PR TITLE
Update namespace to use default namespace.

### DIFF
--- a/example-ruby-manifest/continuum.conf
+++ b/example-ruby-manifest/continuum.conf
@@ -8,7 +8,8 @@ name: "example-ruby-manifest"
 
 # Namespace to which the app belongs
 # Default: Current Namespace
-namespace: "/"
+# To change the namespace, uncomment the line below and update it with the desired namespace.
+# namespace: "/"
 
 # Number of app instances to start on creation
 # Default: 1


### PR DESCRIPTION
I added a system test in https://github.com/apcera/continuum/pull/5620, which uses this sample app to test runtime templates.  Creating job in default namespace instead of `/` is required for the package and app to be created.

@zquestz @lilirui 