### PR TITLE
apcera-job-scaler default Makefile

### DIFF
--- a/apcera-job-scaler/Makefile
+++ b/apcera-job-scaler/Makefile
@@ -1,0 +1,7 @@
+# Default target: builds the project
+default:
+	go install
+
+# Cleans our porject: deletes binaries
+clean:
+	go clean


### PR DESCRIPTION
Makefile to get around 'go get' of the Go Stager which is not needed, since the dependencies for this app are vendored.

@jpoler 