### PR TITLE
Create sample app demoing chown & chmod options

### DIFF
--- a/sudo-demo/README.md
+++ b/sudo-demo/README.md
@@ -1,0 +1,16 @@
+### sudo-demo
+
+This is a sample `bash` application that demonstrates how to use `sudo` to add users, add groups, and `chown` and `chmod` files as `root`.
+
+By default apps run as the user `runner`, group `runner`. If a specific command needs to run as user `root`, preface the command with `sudo`.
+
+To create the app, perform the following:
+
+```
+cd sudo-demo
+apc app create sudo-demo --batch
+apc app start sudo-demo --batch
+```
+
+The app will output the results of the `bash_start.sh` script to the screen.
+

--- a/sudo-demo/bash_start.sh
+++ b/sudo-demo/bash_start.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Demonstrate that Apcera apps can use sudo to add users, add groups, and chown and chmod files as root.
+
+set -e
+
+cd /app
+sudo useradd owner1
+sudo useradd owner2
+sudo useradd owner3
+sudo groupadd group1
+sudo groupadd group2
+sudo groupadd group3
+pwd
+
+touch file1 file2 file3
+ls -al
+echo
+
+sudo chown owner1:group1 file1
+sudo chown owner2:group2 file2
+sudo chown owner3:group3 file3
+ls -al
+echo
+
+sudo chmod 640 file1 file2 file3
+ls -al
+echo
+
+# Don't exit
+touch /app/noexit
+tail -f /app/noexit

--- a/sudo-demo/sudo-demo.conf
+++ b/sudo-demo/sudo-demo.conf
@@ -1,0 +1,13 @@
+name: "sudo-demo"
+
+resources {
+  disk_space: "256MB"
+  memory: "256MB"
+  network_bandwidth: "100Mbps"
+}
+
+package_dependencies: [
+  "os.ubuntu-14.04-apc3"
+]
+
+start: true


### PR DESCRIPTION
This is a sample bash application that demonstrates how to use sudo to add users, add groups, and chown and chmod files as root.

This came out of a reported "bug" that a customer could not chown or chmod a file stored in the container's file system. I could not reproduce the error, but I did notice that we had no sample code that demoed this capability, so I wrote some.

Fixes #ENGT-9932

@mtnlife999 @y0ssar1an @yaso195 @ketandixit 