### PR TITLE
Jenkins: Add variable support for Jenkins MRM

### DIFF
--- a/jenkins/cleanup.sh
+++ b/jenkins/cleanup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+
+apc job delete --batch jenkins-master
+apc job delete --batch jenkins-slave
+
+apc service delete --batch jenkins-slave-nfs
+apc service delete --batch jenkins-master-nfs
+
+apc network delete --batch jenkins
+
+apc package delete --batch jenkins-master
+apc package delete --batch jenkins-slave
+
+apc network delete jenkins

--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# This script will deploy the jenkins manifest on a specified
+# cluster and namespace
+#
+
+
+print_usage()
+{
+    USAGE="deploy.sh <clustername> <namespace> <nfs-provider>"
+    echo $USAGE
+    exit 1
+}
+
+if [ -z "$1" ]; then
+   echo "Please specify the cluster name."
+   print_usage
+else
+   export CLUSTERNAME=$1
+fi
+
+if [ -z "$2" ]; then
+   echo "Please specify the namespace"
+   print_usage
+else
+   export NAMESPACE=$2
+fi
+
+if [ -z "$3" ]; then
+    export NFS_PROVIDER=apcfs
+else
+    export NFS_PROVIDER=$3
+fi
+
+
+apc target https://$CLUSTERNAME
+RET=$?
+if [ ${RET} -ne 0 ]; then
+    print_usage
+    exit 1
+fi
+
+apc namespace $NAMESPACE
+RET=$?
+if [ ${RET} -ne 0 ]; then
+    print_usage
+    exit 1
+fi
+
+apc manifest deploy myapp.json -- \
+  --CLUSTERNAME $CLUSTERNAME --NAMESPACE $NAMESPACE --NFS_PROVIDER $NFS_PROVIDER

--- a/jenkins/myapp.json
+++ b/jenkins/myapp.json
@@ -1,12 +1,12 @@
 {
   "jobs": {
-    "job::/sandbox/demo::jenkins-slave": {
+    "job::${NAMESPACE}::jenkins-slave": {
       "docker": {
         "image": "apcerademos/jenkins:latest"
       },
       "start": {
         "cmd": "bash /slave.sh",
-        "timeout" : 30
+        "timeout" : 120
       },
       "resources": {
         "memory": "2GB",
@@ -20,29 +20,29 @@
           "fqn":    "service::/apcera::http"
         },
         "NFS": {
-          "fqn": "service::/sandbox/demo::jenkins-slave-nfs",
+          "fqn": "service::${NAMESPACE}::jenkins-slave-nfs",
           "params": {
             "mountpath": "/root/.jenkins"
           }
         }
       },
       "env": {
-        "target": "http://demo.apcera.net"
+        "target": "http://jenkins.${CLUSTERNAME}"
       },
       "state": "started",
-      "instances": 3
+      "instances": 1
     },
-    "job::/sandbox/demo::jenkins-master": {
+    "job::${NAMESPACE}::jenkins-master": {
       "docker":  {
         "image": "apcerademos/jenkins:latest"
       },
       "env": {
-        "target": "http://demo.apcera.net"
+        "target": "http://jenkins.${CLUSTERNAME}"
       },
       "state": "started",
       "start": {
         "cmd": "bash /startup.sh",
-        "timeout" : 30
+        "timeout" : 120
       },
       "resources": {
         "memory": "2GB",
@@ -56,7 +56,7 @@
           "fqn":    "service::/apcera::http"
         },
         "NFS": {
-          "fqn": "service::/sandbox/demo::jenkins-master-nfs",
+          "fqn": "service::${NAMESPACE}::jenkins-master-nfs",
           "params": {
             "mountpath": "/root/.jenkins"
           }
@@ -66,7 +66,7 @@
       "routes": [
         {
           "type": "http",
-          "endpoint": "jenkins.demo.apcera.net",
+          "endpoint": "jenkins.${CLUSTERNAME}",
           "config": {
             "/": [
               {
@@ -80,32 +80,24 @@
     }
   },
   "services": {
-    "service::/sandbox/demo::jenkins-master-nfs": {
-      "provider_fqn": "provider::/apcera/providers::apcfs"
+    "service::${NAMESPACE}::jenkins-master-nfs": {
+      "provider_fqn": "provider::/apcera/providers::${NFS_PROVIDER}"
     }
   },
   "services": {
-    "service::/sandbox/demo::jenkins-slave-nfs": {
-      "provider_fqn": "provider::/apcera/providers::apcfs"
+    "service::${NAMESPACE}::jenkins-slave-nfs": {
+      "provider_fqn": "provider::/apcera/providers::${NFS_PROVIDER}"
     }
   },
   "networks": {
-    "network::/sandbox/demo::jenkins": {
+    "network::${NAMESPACE}::jenkins": {
       "jobs": [
         {
-          "fqn": "job::/sandbox/demo::jenkins-master",
-          "discovery_address": "master",
-          "broadcast_enable": true,
-          "multicast_addresses": [
-            "225.1.1.0/24"
-          ]
+          "fqn": "job::${NAMESPACE}::jenkins-master",
+          "discovery_address": "master"
         },
         {
-          "fqn": "job::/sandbox/demo::jenkins-slave",
-          "broadcast_enable": true,
-          "multicast_addresses": [
-            "225.1.1.0/24"
-          ]
+          "fqn": "job::${NAMESPACE}::jenkins-slave"
         }
       ]
     }


### PR DESCRIPTION
This PR introduces variables to the Jenkins MRM, this makes the manifest portable. It also adds a cleanup script to remove jenkins jobs, services, and networks created by the manifest, and adds a script that deploys the manifest.

This is an FYI PR

@jamiesmith @earlruby @carlos-lopez-garces 