### PR TITLE
Updating the manifest file apcera-job-scaler

### DIFF
--- a/apcera-job-scaler/continuum.conf
+++ b/apcera-job-scaler/continuum.conf
@@ -10,13 +10,8 @@ name: "apcera-job-scaler"
 # Default: 1
 instances: 1
 
-# Port definition
-ports: [
-    {
-        number: 8080,
-        optional: true
-    }
-]
+# Disable routes on the job
+disable_routes: true
 
 # Services to create and bind to the app.
 # Providers must be registered prior to app creation.
@@ -43,10 +38,6 @@ env {
 # Timeout in seconds, allocated for app startup time (before timing out)
 # Default: 5 seconds
 timeout: 120
-
-resources {
-    memory: "2048MB"
-}
 
 # Start: boolean that determines if the app should start upon creation
 # Default: false


### PR DESCRIPTION
Default memory of 256MB should do.
Also no ports/routes needed.

@jpoler @juanman2 