### PR TITLE
Updated app manifest for app auto-scaler

### DIFF
--- a/apcera-job-scaler/continuum.conf
+++ b/apcera-job-scaler/continuum.conf
@@ -35,7 +35,6 @@ env {
    "INSTANCE_COUNTER": "1",
 }
 
-
 # Timeout in seconds, allocated for app startup time (before timing out)
 # Default: 5 seconds
 timeout: 120

--- a/apcera-job-scaler/continuum.conf
+++ b/apcera-job-scaler/continuum.conf
@@ -23,6 +23,10 @@ services [
   },
 ]
 
+package_env {
+  GOPROJECT=/src/github.com/apcera/sample-apps/apcera-job-scaler
+}
+
 # App Environment Variables;
 env {
    "API_ENDPOINT": "api.<cluster.domain>",
@@ -38,7 +42,3 @@ env {
 # Timeout in seconds, allocated for app startup time (before timing out)
 # Default: 5 seconds
 timeout: 120
-
-# Start: boolean that determines if the app should start upon creation
-# Default: false
-start: true

--- a/apcera-job-scaler/continuum.conf
+++ b/apcera-job-scaler/continuum.conf
@@ -23,10 +23,6 @@ services [
   },
 ]
 
-package_env {
-  GOPROJECT=/src/github.com/apcera/sample-apps/apcera-job-scaler
-}
-
 # App Environment Variables;
 env {
    "API_ENDPOINT": "api.<cluster.domain>",
@@ -39,6 +35,17 @@ env {
    "INSTANCE_COUNTER": "1",
 }
 
+
 # Timeout in seconds, allocated for app startup time (before timing out)
 # Default: 5 seconds
 timeout: 120
+
+# Start: boolean that determines if the app should start upon creation
+# Default: false
+start: true
+
+# Set environment variable on application package so the Go stager can locate
+# package dependencies, regardless of where you cloned the sample app on your local system.
+package_env {
+    GOPROJECT=/src/github.com/apcera/sample-apps/apcera-job-scaler
+}


### PR DESCRIPTION
* Added `GOPROJECT` package environment variable, per discussion with @shatrugna. This avoids users getting Go build errors during staging if they don't have their Go development environment configured correctly (or at all). This is important for our training attendees who are generally not Go developers and just want to use the app with minimal setup.
~~* Also: To avoid WAMP/realm errors on startup due to missing app token policy, changed auto-scaler app to not start after deploy. The updated tutorial in the README (see https://github.com/apcera/sample-apps/pull/75) now instructs users to start the auto-scaler with APC, after they've added the necessary policy.~~

@shatrugna @jpoler fyi @rjdavidburke/@yhyakuna