### PR TITLE
WAMP Event Topic workaround removed

### DIFF
--- a/example-node-event-client/index.js
+++ b/example-node-event-client/index.js
@@ -2,13 +2,8 @@
 
 var autobahn = require('autobahn');
 
-// Work-around for docs.apcera.com/api/events-system-api/#wamp-compat
-autobahn.Session.prototype.resolve = function(value) {
-    return value
-}
-
 // WAMP subscription topic FQN. Your API token must allow read access to this resource.
-var subscribeFQN = "job::/apcera";
+var subscribeFQN = encodeURIComponent("job::/apcera");
 
 // Read API token from environment. Required for running outside the cluster.
 var token = process.env.BEARER_TOKEN;


### PR DESCRIPTION
WAMP Event Topic workaround not needed with autobahn JS anymore with https://github.com/apcera/continuum/pull/5686.

The example was previously over-writing https://github.com/crossbario/autobahn-js/blob/master/lib/session.js#L1493

@tstatler 