### PR TITLE
Revert "WAMP Event Topic workaround removed"

### DIFF
--- a/example-node-event-client/index.js
+++ b/example-node-event-client/index.js
@@ -2,8 +2,13 @@
 
 var autobahn = require('autobahn');
 
+// Work-around for docs.apcera.com/api/events-system-api/#wamp-compat
+autobahn.Session.prototype.resolve = function(value) {
+    return value
+}
+
 // WAMP subscription topic FQN. Your API token must allow read access to this resource.
-var subscribeFQN = encodeURIComponent("job::/apcera");
+var subscribeFQN = "job::/apcera";
 
 // Read API token from environment. Required for running outside the cluster.
 var token = process.env.BEARER_TOKEN;


### PR DESCRIPTION
Reverts apcera/sample-apps#77

The current promoted release (2.4.2) does not include the fix for this issue (https://github.com/apcera/continuum/pull/5686), so this work-around is still necessary. 

I confirmed this by deploying with `apcera-setup install` (which takes the latest promoted build) and testing this Node sample app with the old workaround (library mod) and with `encodeURIComponent()` call. It works with the old workaround, but when trying with the `encodeURIComponent()` call it errors with:

```
[stdout] Subscription failed for 'job%3A%3A%2Fapcera'
```

@shatrugna cc @lparis 