### PR TITLE
remove apc, update README, add retries and sleeps

### DIFF
--- a/jenkins/README.MD
+++ b/jenkins/README.MD
@@ -1,15 +1,22 @@
 # About
 
-Contains the Dockerfile and startup scripts to run a Jenkins cluster on Apcera. Feel free to test this out on the Apcera Platform Community or Enterprise Edition https://www.apcera.com/community-edition
+Contains the Dockerfile and startup scripts to run a Jenkins cluster on Apcera. This project contains instructions about how to use the docker image in the apcerademos
+repository for the docker hub.  It describes how to deploy the image and set it up in your environment using two different methods.  It also describes how to create
+your own dockerfile that will work on the apcera platform.
 
-# Build the Docker image
+Feel free to test this out on the Apcera Platform Community or Enterprise Edition https://www.apcera.com/community-edition
 
-Please adjust line 4 of the Dockerfile to point to your own Apcera Cluster so the appropriate APC version will be installed. When done, you can build the Docker image and push it to a public registry.
+# Using Multi-Resource Manifest
+With the multi-resource manifest you can establish a single descriptive declarative file that can deploy the Jenkins and its Jenkins-slave, including apcera services, the network, routes, and in a single command deploys the application end-to-end. The file, jenkins-manifest.json includes variables so it is portable. Please see the file deploy.sh for details, also look at the cleanup.sh script that cleans up the work that the deploy script did.
+
+To use the manifest and the helper script end to end you will need to issue first edit and import the policy then deploy the manifest, here is an example:
+
 ```
-cd jenkins
-docker build -t my-repo/jenkins .
-docker push my-repo/jenkins
+apc policy import jenkins.pol
+deploy.sh bagel.buffalo.im /sandbox/juan apcfs-ha
 ```
+For more information on multi-resource manifests see: http://docs.apcera.com/jobs/multi-resource-manifests/
+
 
 # Running the Docker image using the APC CLI
 ## Run the Docker image on Apcera
@@ -54,21 +61,17 @@ apc app start jenkins-slave
 apc app update jenkins-slave -i 3 --batch
 ```
 
-# Using Multi-Resource Manifest
-The with the multi-resource manifest you can establish a single descriptive declarative file that can deploy the whole application, including adding both jobs, services, network, routes, and in a single command deploys the application end-to-end. The file, jenkins-manifest.json includes variables so it is portable. Please see the file deploy.sh for details, it executes this command at the end:
+# Building the Docker image
 
-```
-apc manifest deploy jenkins-manifest.json -- \
-  --CLUSTERNAME $CLUSTERNAME --NAMESPACE $NAMESPACE --NFS_PROVIDER $NFS_PROVIDER
-```
+If you do not want to use Apcera's Jenkins docker image, you can build your own and adjust the manifest to reflect this.  Please follow the steps below to create a new jenkins docker image.
 
-To use the manifest and the helper script end to end you will need to issue first edit and import the policy then deploy the manifest, here is an example:
-
+Adjust line 4 of the Dockerfile to point to your own Apcera Cluster so the appropriate APC version will be installed. When done, you can build the Docker image and push it to a public registry.  Then execute the following commands:
 ```
-apc policy import jenkins.pol
-deploy.sh bagel.buffalo.im /sandbox/juan apcfs-ha
+cd jenkins
+docker build -t my-repo/jenkins .
+docker push my-repo/jenkins
 ```
-For more information on multi-resource manifests see: http://docs.apcera.com/jobs/multi-resource-manifests/
+You can then modify the _image_ portion of the resource manifest, or change the _-i_ argument to the docker run command.
 
 # Jenkins CLI
 

--- a/jenkins/README.MD
+++ b/jenkins/README.MD
@@ -22,7 +22,7 @@ For more information on multi-resource manifests see: http://docs.apcera.com/job
 ## Run the Docker image on Apcera
 Use APC to create a Jenkins master job from your Docker registry. The -r flag assigns a public route for you to access Jenkins. The envrionment variable "target" should reflect the address of the Apcera cluster. The provider flag sets up persistent storage for the Jenkins directory: /root/.jenkins.
 ```
-apc docker run jenkins-master -i my-repo/jenkins -m 2G -d 5G --port 8080 -ae -r http://master-jenkins.demo.apcera.net -e target="http://demo.apcera.net" --provider  /apcera/providers::apcfs --batch --no-start
+apc docker run jenkins-master -i my-repo/jenkins -m 4G -d 5G --port 8080 -ae -r http://master-jenkins.demo.apcera.net -e target="http://demo.apcera.net" --provider  /apcera/providers::apcfs --batch --no-start
 ```
 
 Use APC to create the Jenkins slave job from your Docker registry. Here we need to change the startup command with the -s flag because the slave nodes require a different application to connect to the Jenkins master.

--- a/jenkins/README.MD
+++ b/jenkins/README.MD
@@ -22,12 +22,12 @@ For more information on multi-resource manifests see: http://docs.apcera.com/job
 ## Run the Docker image on Apcera
 Use APC to create a Jenkins master job from your Docker registry. The -r flag assigns a public route for you to access Jenkins. The envrionment variable "target" should reflect the address of the Apcera cluster. The provider flag sets up persistent storage for the Jenkins directory: /root/.jenkins.
 ```
-apc docker run jenkins-master -i my-repo/jenkins -m 4G -d 5G --port 8080 -ae -r http://master-jenkins.demo.apcera.net -e target="http://demo.apcera.net" --provider  /apcera/providers::apcfs --batch --no-start
+apc docker run jenkins-master -i my-repo/jenkins -m 4G -d 5G --port 8080 -ae -r http://master-jenkins.demo.apcera.net -e TARGET="http://demo.apcera.net" --provider  /apcera/providers::apcfs --batch --no-start
 ```
 
 Use APC to create the Jenkins slave job from your Docker registry. Here we need to change the startup command with the -s flag because the slave nodes require a different application to connect to the Jenkins master.
 ```
-apc docker run jenkins-slave -i my-repo/jenkins -m 2G -d 5G --port 8080 -ae -s "bash /slave.sh" -e target="http://demo.apcera.net" --provider /apcera/providers::apcfs --batch --no-start
+apc docker run jenkins-slave -i my-repo/jenkins -m 2G -d 5G --port 8080 -ae -s "bash /slave.sh" -e TARGET="http://demo.apcera.net" --provider /apcera/providers::apcfs --batch --no-start
 ```
 
 ## Configure the networking

--- a/jenkins/jenkins-manifest.json
+++ b/jenkins/jenkins-manifest.json
@@ -1,7 +1,7 @@
 {
   "jobs": {
-    "job::${NAMESPACE}::jenkins-docker": {
-      "slave": {
+    "job::${NAMESPACE}::jenkins-slave": {
+      "docker": {
         "image": "apcerademos/jenkins:latest"
       },
       "start": {
@@ -97,5 +97,4 @@
       ]
     }
   }
-
 }

--- a/jenkins/jenkins-manifest.json
+++ b/jenkins/jenkins-manifest.json
@@ -1,7 +1,7 @@
 {
   "jobs": {
-    "job::${NAMESPACE}::jenkins-slave": {
-      "docker": {
+    "job::${NAMESPACE}::jenkins-docker": {
+      "slave": {
         "image": "apcerademos/jenkins:latest"
       },
       "start": {
@@ -45,7 +45,7 @@
         "timeout" : 120
       },
       "resources": {
-        "memory": "2GB",
+        "memory": "4GB",
         "disk_space": "5GB"
       },
       "services": {

--- a/jenkins/slave.sh
+++ b/jenkins/slave.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-# Apcera apc CLI
-route=`echo $TARGET | cut -d '/' -f3`
-wget https://api.${route}/v1/apc/download/linux_amd64/apc.zip
-unzip apc.zip -d /usr/local/bin
-apc target $TARGET
-apc login --app-auth
+# TARGET must be set when deployed to an Apcera cluster.
+if [ -z "$TARGET" ]; then
+    echo "$0:Please set the TARGET environment variable"
+    exit 1
+else
+    echo "$0: TARGET CLUSTER is ${TARGET}";echo
+fi
+MASTER="http://master.apcera.local:8080"
 
-# start the slave
-java -jar cli.jar -fsroot /root/.jenkins/workspace -master http://master.apcera.local:8080 -executors 1
+
+java -jar cli.jar -fsroot /root/.jenkins/workspace -master ${MASTER} -executors 1


### PR DESCRIPTION
This PR removes APC from the Dockerfile, startup.sh, and slave.sh.  It updates the README to be more explicit about how to use the image.

Please review:
@yhyakuna @tstatler 