### PR TITLE
fix restart, move jenkins_home from .jenkins

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,11 +1,11 @@
 FROM ubuntu
-VOLUME /root/.jenkins
+VOLUME /var/jenkins_home
 USER root
 RUN apt-get update;apt-get install curl wget -y
 RUN wget -q -O - https://jenkins-ci.org/debian/jenkins-ci.org.key | apt-key add -
 RUN echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list
 RUN apt-get update;apt-get -y install ant openjdk-8-jre-headless tar git zip unzip jenkins
-RUN curl -o cli.jar http://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/2.1/swarm-client-2.1-jar-with-dependencies.jar
+RUN curl -o /cli.jar http://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/2.1/swarm-client-2.1-jar-with-dependencies.jar
 ADD slave.sh /
 ADD startup.sh /
 ENV PATH=$PATH:/

--- a/jenkins/jenkins-manifest.json
+++ b/jenkins/jenkins-manifest.json
@@ -2,7 +2,7 @@
   "jobs": {
     "job::${NAMESPACE}::jenkins-slave": {
       "docker": {
-        "image": "apcerademos/jenkins:test"
+        "image": "apcerademos/jenkins:latest"
       },
       "start": {
         "cmd": "bash /slave.sh",
@@ -35,7 +35,7 @@
     },
     "job::${NAMESPACE}::jenkins-master": {
       "docker":  {
-        "image": "apcerademos/jenkins:test"
+        "image": "apcerademos/jenkins:latest"
       },
       "env": {
           "TARGET": "http://${CLUSTERNAME}",

--- a/jenkins/jenkins-manifest.json
+++ b/jenkins/jenkins-manifest.json
@@ -2,7 +2,7 @@
   "jobs": {
     "job::${NAMESPACE}::jenkins-slave": {
       "docker": {
-        "image": "apcerademos/jenkins:latest"
+        "image": "apcerademos/jenkins:test"
       },
       "start": {
         "cmd": "bash /slave.sh",
@@ -22,22 +22,24 @@
         "NFS": {
           "fqn": "service::${NAMESPACE}::jenkins-master-nfs",
           "params": {
-            "mountpath": "/root/.jenkins"
+            "mountpath": "/var/jenkins_home"
           }
         }
       },
       "env": {
-        "TARGET": "http://${CLUSTERNAME}"
+          "TARGET": "http://${CLUSTERNAME}",
+          "JENKINS_HOME": "/var/jenkins_home"
       },
       "state": "started",
       "instances": 1
     },
     "job::${NAMESPACE}::jenkins-master": {
       "docker":  {
-        "image": "apcerademos/jenkins:latest"
+        "image": "apcerademos/jenkins:test"
       },
       "env": {
-        "TARGET": "http://${CLUSTERNAME}"
+          "TARGET": "http://${CLUSTERNAME}",
+          "JENKINS_HOME": "/var/jenkins_home"
       },
       "state": "started",
       "start": {
@@ -58,7 +60,7 @@
         "NFS": {
           "fqn": "service::${NAMESPACE}::jenkins-master-nfs",
           "params": {
-            "mountpath": "/root/.jenkins"
+            "mountpath": "/var/jenkins_home"
           }
         }
       },

--- a/jenkins/slave.sh
+++ b/jenkins/slave.sh
@@ -8,6 +8,7 @@ else
     echo "$0: TARGET CLUSTER is ${TARGET}";echo
 fi
 MASTER="http://master.apcera.local:8080"
+JENKINS_HOME=/var/jenkins_home
 
 
-java -jar cli.jar -fsroot /root/.jenkins/workspace -master ${MASTER} -executors 1
+java -jar /cli.jar -fsroot ${JENKINS_HOME}/workspace -master ${MASTER} -executors 1

--- a/jenkins/startup.sh
+++ b/jenkins/startup.sh
@@ -3,6 +3,9 @@
 # This script is used to start jenkins inside an Apcera Cluster
 #
 PLUGIN_LIST="swarm github workflow-aggregator workflow-job workflow-basic-steps"
+JENKINS_HOST=http://127.0.0.1:8080
+JENKINS_HOME=/var/jenkins_home
+cd $JENKINS_HOME
 
 # TARGET must be set when deployed to an Apcera cluster.
 if [ -z "$TARGET" ]; then
@@ -20,8 +23,8 @@ java $JAVA_OPTS -jar /usr/share/jenkins/jenkins.war&
 sleep 15
 
 echo "$0: Jenkins check on installed plugins .. ";echo
-COUNT=15
-until java -jar /root/.jenkins/war/WEB-INF/jenkins-cli.jar -s http://127.0.0.1:8080/ list-plugins > INSTALLED_PLUGINS 2>/dev/null
+COUNT=40
+until java -jar ${JENKINS_HOME}/war/WEB-INF/jenkins-cli.jar -s ${JENKINS_HOST} list-plugins > INSTALLED_PLUGINS 2>/dev/null
 do
     echo "$0: Jenkins is not ready .. ";echo
     sleep 3
@@ -39,17 +42,25 @@ do
         echo "$0: Found plugin $p installed .. "; echo
     else
         echo "$0: Installing plugin $p"; echo
-        java -jar /root/.jenkins/war/WEB-INF/jenkins-cli.jar -s http://127.0.0.1:8080/ install-plugin ${p}
+        java -jar ${JENKINS_HOME}/war/WEB-INF/jenkins-cli.jar -s ${JENKINS_HOST} install-plugin ${p}
         RESTART=true
     fi
 done
 
 if [ "${RESTART}" == "true" ]; then
     echo "$0: Restarting Jenkins to activate plugins ...";echo
-    java -jar /root/.jenkins/war/WEB-INF/jenkins-cli.jar -s http://127.0.0.1:8080/ restart
-    sleep 2
-    echo "$0: Exiting ...";echo
-    exit 1
+    java -jar ${JENKINS_HOME}/war/WEB-INF/jenkins-cli.jar -s ${JENKINS_HOST} restart
+    echo "$0: Jenkins re-starting .. ";echo
+    COUNT=30
+    until kill -0 `pidof java` 2> /dev/null ; do
+        echo "$0: Jenkins is not up yet .. ";echo
+        sleep 3
+        COUNT=$((COUNT-1))
+        if [ ${COUNT} -eq "0" ]; then
+            echo "$0: Exiting, will retry ... ";echo
+            exit 1
+        fi
+    done
 fi
 
 echo "$0: Sleeping forever ...";echo


### PR DESCRIPTION
This FYI PR moves the jenkins home from /root/.jenkins to /var/jenkins_home.  The manifest is updated to do this.  It also changes restart after installing the plugins so that we wait instead of failing and restarting.  This means that we do not end up hanging on the war extraction.  For some reason, if we crash on restart the extraction hangs the second time around.  By waiting for jenkins to restart normally, the install happens in one pass.

@yhyakuna 
@tstatler 

I will merge this now, please let me know if there are problems.