### PR TITLE
Close memcache connections in example-ruby-memcache

### DIFF
--- a/example-ruby-memcache/app.rb
+++ b/example-ruby-memcache/app.rb
@@ -15,11 +15,16 @@ class App < Sinatra::Base
   end
 
   get "/get/:key" do |key|
-    dalli.get(key)
+    client = dalli
+    value = client.get(key)
+    client.close()
+    value
   end
 
   get "/set/:key/:value" do |key,value|
-    dalli.set(key, value)
+    client = dalli
+    client.set(key, value)
+    client.close()
     "OK"
   end
 end


### PR DESCRIPTION
example-ruby-memcache doesn't close connections to the
Memcache server (or Memcache SP); every request to the
app creates a client and uses that client to make a
request and return the server's response. But the
connection is not closed explicitly.

The Memcache SP expects [EOF](https://github.com/apcera/sp/blob/master/memcache/binary.go#L174) when the client disconnects;
EOF causes the SP to stop reading from the connection and
exit. If EOF is not found at the end of the connection,
the reads made by the SP [will timeout and it will retry
again indefinitely](https://github.com/apcera/sp/blob/master/memcache/binary.go#L180).

Have each request to example-ruby-memcache close its
Memcache connection, so that the SP read EOF and exit.

The Memcache SP also needs to be fixed. The fix could just be to count the number of times the reads timeout and if the number reaches some maximum, exit. But I need to think about it more.