### PR TITLE
APCERA-46: Add continuum.conf to go-nats for req'd Go version

### DIFF
--- a/go-nats/continuum.conf
+++ b/go-nats/continuum.conf
@@ -1,0 +1,3 @@
+package_dependencies: [
+        "runtime.go-1.9"
+]


### PR DESCRIPTION
NATS needs to be built with version 1.9 of Go or higher, because
its nats-io/nkeys dependency uses symbols that aren't found in
lower versions.